### PR TITLE
Fix payment notification if RPC node returns error 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,7 +36,6 @@ def create_app():
     from .api import metrics_blueprint
     app.register_blueprint(metrics_blueprint)
 
-    from .tasks import walletnotify_shkeeper
 
     db.init_app(app)
     with app.app_context():

--- a/app/events.py
+++ b/app/events.py
@@ -9,7 +9,7 @@ from .coin import Coin, get_all_accounts
 
 
 def log_loop(last_checked_block, check_interval):
-    from .tasks import walletnotify_shkeeper, drain_account
+    from .tasks import drain_account
     from app import create_app
     app = create_app()
     app.app_context().push()
@@ -66,7 +66,7 @@ def log_loop(last_checked_block, check_interval):
                                         drain_account.delay(token_dict[balance["mint"]], balance['owner'])
                     symbols_set = set(symbols)
                     for symbol in symbols_set:
-                        walletnotify_shkeeper.delay(symbol, transaction_json['transaction']['signatures'][0])
+                        coin.walletnotify_shkeeper(symbol, transaction_json['transaction']['signatures'][0])
                 return 1
             with ThreadPoolExecutor(max_workers=config['EVENTS_MAX_THREADS_NUMBER']) as executor:
                 try:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -47,21 +47,6 @@ def post_payout_results(data, symbol):
 
 
 @celery.task()
-def walletnotify_shkeeper(symbol, txid):
-    logger.warning(f"Notifying about {symbol}/{txid}")
-    while True:
-        try:
-            r = rq.post(
-                    f'http://{config["SHKEEPER_HOST"]}/api/v1/walletnotify/{symbol}/{txid}',
-                    headers={'X-Shkeeper-Backend-Key': config['SHKEEPER_KEY']}
-                )
-            return r
-        except Exception as e:
-            logger.warning(f'Shkeeper notification failed for {symbol}/{txid}: {e}')
-            time.sleep(10)
-
-
-@celery.task()
 def refresh_balances():
     updated = 0
 


### PR DESCRIPTION
Fix:
- Notification moved from tasks to the event module for synchronous notification during block scanning.
- Added a retry mechanism to ensure re-notification until SHKeeper confirms success.
- Improved error handling for RPC responses to detect and log failures.
- Ensured that notifications persist until a confirmed success response is received.
- Scanning does not continue until the SHKeeper confirms the notification.